### PR TITLE
シーンオフセット反映と親Animator階層のファイル名対応を追加

### DIFF
--- a/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Scripts/Editor/Application/AnimationMergeService.cs
+++ b/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Scripts/Editor/Application/AnimationMergeService.cs
@@ -359,7 +359,7 @@ namespace AnimationMergeTool.Editor.Application
 
             // AnimationClipを生成
             var timelineAssetName = timelineAsset.name;
-            var animatorName = animator != null ? animator.name : "NoAnimator";
+            var animatorName = FileNameGenerator.GetHierarchicalAnimatorName(animator);
 
             if (saveToAsset)
             {
@@ -410,7 +410,12 @@ namespace AnimationMergeTool.Editor.Application
                     continue;
                 }
 
-                clipInfos.Add(new ClipInfo(timelineClip, animationPlayableAsset.clip));
+                // AnimationPlayableAssetからシーンオフセット（Position/Rotation）を取得
+                var offsetPosition = animationPlayableAsset.position;
+                var offsetRotation = animationPlayableAsset.rotation;
+
+                clipInfos.Add(new ClipInfo(timelineClip, animationPlayableAsset.clip,
+                    offsetPosition, offsetRotation));
             }
 
             return clipInfos;
@@ -578,7 +583,7 @@ namespace AnimationMergeTool.Editor.Application
             }
 
             // ファイルパスを生成
-            var animatorName = mergeResult.TargetAnimator != null ? mergeResult.TargetAnimator.name : "NoAnimator";
+            var animatorName = FileNameGenerator.GetHierarchicalAnimatorName(mergeResult.TargetAnimator);
             var outputPath = _fileNameGenerator.GenerateUniqueFilePath(
                 outputDirectory,
                 timelineAssetName,

--- a/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Scripts/Editor/Domain/Models/ClipInfo.cs
+++ b/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Scripts/Editor/Domain/Models/ClipInfo.cs
@@ -19,6 +19,18 @@ namespace AnimationMergeTool.Editor.Domain.Models
         public AnimationClip AnimationClip { get; }
 
         /// <summary>
+        /// シーンオフセット位置（AnimationPlayableAsset.position）
+        /// Hierarchy上で手動設定されたPosition値
+        /// </summary>
+        public Vector3 SceneOffsetPosition { get; }
+
+        /// <summary>
+        /// シーンオフセット回転（AnimationPlayableAsset.rotation）
+        /// Hierarchy上で手動設定されたRotation値
+        /// </summary>
+        public Quaternion SceneOffsetRotation { get; }
+
+        /// <summary>
         /// 開始時間（秒）
         /// </summary>
         public double StartTime => TimelineClip?.start ?? 0;
@@ -81,10 +93,32 @@ namespace AnimationMergeTool.Editor.Domain.Models
         /// <param name="timelineClip">TimelineClip参照</param>
         /// <param name="animationClip">AnimationClip参照</param>
         public ClipInfo(TimelineClip timelineClip, AnimationClip animationClip)
+            : this(timelineClip, animationClip, Vector3.zero, Quaternion.identity)
+        {
+        }
+
+        /// <summary>
+        /// コンストラクタ（シーンオフセット付き）
+        /// </summary>
+        /// <param name="timelineClip">TimelineClip参照</param>
+        /// <param name="animationClip">AnimationClip参照</param>
+        /// <param name="sceneOffsetPosition">シーンオフセット位置</param>
+        /// <param name="sceneOffsetRotation">シーンオフセット回転</param>
+        public ClipInfo(TimelineClip timelineClip, AnimationClip animationClip,
+            Vector3 sceneOffsetPosition, Quaternion sceneOffsetRotation)
         {
             TimelineClip = timelineClip;
             AnimationClip = animationClip;
+            SceneOffsetPosition = sceneOffsetPosition;
+            SceneOffsetRotation = sceneOffsetRotation;
         }
+
+        /// <summary>
+        /// シーンオフセットが設定されているかどうか
+        /// </summary>
+        public bool HasSceneOffset =>
+            SceneOffsetPosition != Vector3.zero ||
+            SceneOffsetRotation != Quaternion.identity;
 
         /// <summary>
         /// クリップが有効かどうか（TimelineClipとAnimationClipが両方存在する）

--- a/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Scripts/Editor/Domain/SceneOffsetApplier.cs
+++ b/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Scripts/Editor/Domain/SceneOffsetApplier.cs
@@ -1,0 +1,276 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace AnimationMergeTool.Editor.Domain
+{
+    /// <summary>
+    /// AnimationPlayableAssetのシーンオフセット（Position/Rotation）を
+    /// アニメーションカーブに適用するクラス
+    /// </summary>
+    public class SceneOffsetApplier
+    {
+        // ルートTransformのPositionプロパティ名
+        private static readonly string[] PositionPropertyNames =
+        {
+            "m_LocalPosition.x",
+            "m_LocalPosition.y",
+            "m_LocalPosition.z"
+        };
+
+        // ルートTransformのRotationプロパティ名（Quaternion）
+        private static readonly string[] RotationPropertyNames =
+        {
+            "m_LocalRotation.x",
+            "m_LocalRotation.y",
+            "m_LocalRotation.z",
+            "m_LocalRotation.w"
+        };
+
+        // Humanoidルートモーション Positionプロパティ名
+        private static readonly string[] RootMotionPositionPropertyNames =
+        {
+            "RootT.x",
+            "RootT.y",
+            "RootT.z"
+        };
+
+        // Humanoidルートモーション Rotationプロパティ名
+        private static readonly string[] RootMotionRotationPropertyNames =
+        {
+            "RootQ.x",
+            "RootQ.y",
+            "RootQ.z",
+            "RootQ.w"
+        };
+
+        /// <summary>
+        /// カーブリストにシーンオフセットを適用する
+        /// Positionオフセット: ルートTransformのPositionカーブに加算
+        /// Rotationオフセット: ルートTransformのRotationカーブにクォータニオン乗算
+        /// </summary>
+        /// <param name="curveBindingPairs">適用対象のカーブリスト（変更される）</param>
+        /// <param name="positionOffset">Positionオフセット</param>
+        /// <param name="rotationOffset">Rotationオフセット</param>
+        /// <returns>オフセット適用後のカーブリスト</returns>
+        public List<CurveBindingPair> Apply(
+            List<CurveBindingPair> curveBindingPairs,
+            Vector3 positionOffset,
+            Quaternion rotationOffset)
+        {
+            if (curveBindingPairs == null || curveBindingPairs.Count == 0)
+            {
+                return curveBindingPairs;
+            }
+
+            var hasPositionOffset = positionOffset != Vector3.zero;
+            var hasRotationOffset = rotationOffset != Quaternion.identity;
+
+            if (!hasPositionOffset && !hasRotationOffset)
+            {
+                return curveBindingPairs;
+            }
+
+            var result = new List<CurveBindingPair>(curveBindingPairs.Count);
+
+            // Positionオフセットの適用
+            if (hasPositionOffset)
+            {
+                ApplyPositionOffset(curveBindingPairs, result, positionOffset);
+            }
+
+            // Rotationオフセットの適用
+            if (hasRotationOffset)
+            {
+                ApplyRotationOffset(curveBindingPairs, result, rotationOffset);
+            }
+
+            // オフセット適用対象外のカーブをそのまま追加
+            foreach (var pair in curveBindingPairs)
+            {
+                if (!result.Any(r =>
+                    r.Binding.path == pair.Binding.path &&
+                    r.Binding.propertyName == pair.Binding.propertyName &&
+                    r.Binding.type == pair.Binding.type))
+                {
+                    result.Add(pair);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Positionオフセットを適用する
+        /// </summary>
+        private void ApplyPositionOffset(
+            List<CurveBindingPair> source,
+            List<CurveBindingPair> result,
+            Vector3 offset)
+        {
+            var offsetComponents = new[] { offset.x, offset.y, offset.z };
+
+            // Transform Positionカーブ
+            ApplyAdditiveOffset(source, result, PositionPropertyNames, offsetComponents, typeof(Transform));
+            // Humanoid RootT カーブ
+            ApplyAdditiveOffset(source, result, RootMotionPositionPropertyNames, offsetComponents, typeof(Animator));
+        }
+
+        /// <summary>
+        /// 加算オフセットをカーブに適用する
+        /// </summary>
+        private void ApplyAdditiveOffset(
+            List<CurveBindingPair> source,
+            List<CurveBindingPair> result,
+            string[] propertyNames,
+            float[] offsets,
+            System.Type bindingType)
+        {
+            for (var i = 0; i < propertyNames.Length && i < offsets.Length; i++)
+            {
+                if (Mathf.Approximately(offsets[i], 0f))
+                {
+                    continue;
+                }
+
+                var propertyName = propertyNames[i];
+                var offsetValue = offsets[i];
+
+                var pair = FindRootCurve(source, propertyName, bindingType);
+                if (pair == null)
+                {
+                    continue;
+                }
+
+                var newCurve = new AnimationCurve();
+                foreach (var key in pair.Curve.keys)
+                {
+                    var newKey = new Keyframe(key.time, key.value + offsetValue)
+                    {
+                        inTangent = key.inTangent,
+                        outTangent = key.outTangent,
+                        inWeight = key.inWeight,
+                        outWeight = key.outWeight,
+                        weightedMode = key.weightedMode
+                    };
+                    newCurve.AddKey(newKey);
+                }
+
+                result.Add(new CurveBindingPair(pair.Binding, newCurve));
+            }
+        }
+
+        /// <summary>
+        /// Rotationオフセットを適用する
+        /// クォータニオン乗算で適用: newQ = offsetQ * originalQ
+        /// </summary>
+        private void ApplyRotationOffset(
+            List<CurveBindingPair> source,
+            List<CurveBindingPair> result,
+            Quaternion offset)
+        {
+            // Transform Rotation カーブ
+            ApplyQuaternionOffset(source, result, RotationPropertyNames, offset, typeof(Transform));
+            // Humanoid RootQ カーブ
+            ApplyQuaternionOffset(source, result, RootMotionRotationPropertyNames, offset, typeof(Animator));
+        }
+
+        /// <summary>
+        /// クォータニオンオフセットをカーブに適用する
+        /// </summary>
+        private void ApplyQuaternionOffset(
+            List<CurveBindingPair> source,
+            List<CurveBindingPair> result,
+            string[] propertyNames,
+            Quaternion offset,
+            System.Type bindingType)
+        {
+            // 4つのクォータニオンコンポーネントカーブを取得
+            var curves = new CurveBindingPair[4];
+            var allFound = true;
+            for (var i = 0; i < 4; i++)
+            {
+                curves[i] = FindRootCurve(source, propertyNames[i], bindingType);
+                if (curves[i] == null)
+                {
+                    allFound = false;
+                }
+            }
+
+            // 4つのカーブがすべて揃っていない場合はスキップ
+            if (!allFound)
+            {
+                return;
+            }
+
+            // 既にresultに追加済みのカーブと重複しないよう確認
+            if (result.Any(r => r.Binding.path == "" && r.Binding.propertyName == propertyNames[0] && r.Binding.type == bindingType))
+            {
+                return;
+            }
+
+            // 全カーブのユニークなキーフレーム時間を収集
+            var allTimes = new SortedSet<float>();
+            foreach (var curve in curves)
+            {
+                foreach (var key in curve.Curve.keys)
+                {
+                    allTimes.Add(key.time);
+                }
+            }
+
+            // 新しい4つのカーブを作成
+            var newCurves = new AnimationCurve[4];
+            for (var i = 0; i < 4; i++)
+            {
+                newCurves[i] = new AnimationCurve();
+            }
+
+            // 各時間でクォータニオン乗算を適用
+            foreach (var time in allTimes)
+            {
+                var originalQ = new Quaternion(
+                    curves[0].Curve.Evaluate(time),
+                    curves[1].Curve.Evaluate(time),
+                    curves[2].Curve.Evaluate(time),
+                    curves[3].Curve.Evaluate(time)
+                );
+
+                var newQ = offset * originalQ;
+
+                newCurves[0].AddKey(new Keyframe(time, newQ.x));
+                newCurves[1].AddKey(new Keyframe(time, newQ.y));
+                newCurves[2].AddKey(new Keyframe(time, newQ.z));
+                newCurves[3].AddKey(new Keyframe(time, newQ.w));
+            }
+
+            // 結果に追加
+            for (var i = 0; i < 4; i++)
+            {
+                result.Add(new CurveBindingPair(curves[i].Binding, newCurves[i]));
+            }
+        }
+
+        /// <summary>
+        /// ルートパス（path==""）のカーブを検索する
+        /// </summary>
+        private CurveBindingPair FindRootCurve(
+            List<CurveBindingPair> pairs,
+            string propertyName,
+            System.Type bindingType)
+        {
+            foreach (var pair in pairs)
+            {
+                if (pair.Binding.path == "" &&
+                    pair.Binding.propertyName == propertyName &&
+                    pair.Binding.type == bindingType)
+                {
+                    return pair;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Scripts/Editor/Domain/SceneOffsetApplier.cs.meta
+++ b/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Scripts/Editor/Domain/SceneOffsetApplier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b562f0cb2ea523643b8c57e64b9b2256

--- a/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Scripts/Editor/Infrastructure/FileNameGenerator.cs
+++ b/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Scripts/Editor/Infrastructure/FileNameGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine;
 
 namespace AnimationMergeTool.Editor.Infrastructure
 {
@@ -49,6 +50,55 @@ namespace AnimationMergeTool.Editor.Infrastructure
         }
 
         private const string DefaultExtension = ".anim";
+
+        /// <summary>
+        /// Animatorの階層を考慮した名前を生成する
+        /// 親Animatorが存在する場合: "親Animator名_子Animator名"
+        /// 親Animatorが存在しない場合: "Animator名"
+        /// </summary>
+        /// <param name="animator">対象のAnimator</param>
+        /// <returns>階層を考慮したAnimator名</returns>
+        public static string GetHierarchicalAnimatorName(Animator animator)
+        {
+            if (animator == null)
+            {
+                return "NoAnimator";
+            }
+
+            var parentAnimator = FindParentAnimator(animator);
+            if (parentAnimator != null)
+            {
+                return $"{parentAnimator.gameObject.name}_{animator.gameObject.name}";
+            }
+
+            return animator.gameObject.name;
+        }
+
+        /// <summary>
+        /// Hierarchy内で最も近い親のAnimatorを探す
+        /// </summary>
+        /// <param name="animator">対象のAnimator</param>
+        /// <returns>親Animator（存在しない場合はnull）</returns>
+        private static Animator FindParentAnimator(Animator animator)
+        {
+            if (animator == null)
+            {
+                return null;
+            }
+
+            var parent = animator.transform.parent;
+            while (parent != null)
+            {
+                var parentAnimator = parent.GetComponent<Animator>();
+                if (parentAnimator != null)
+                {
+                    return parentAnimator;
+                }
+                parent = parent.parent;
+            }
+
+            return null;
+        }
 
         /// <summary>
         /// 基本ファイル名を生成する

--- a/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Scripts/Editor/UI/ContextMenuHandler.cs
+++ b/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Scripts/Editor/UI/ContextMenuHandler.cs
@@ -474,7 +474,7 @@ namespace AnimationMergeTool.Editor.UI
         /// <returns>出力パス</returns>
         private static string GenerateFbxOutputPath(string baseName, Animator animator)
         {
-            var animatorName = animator != null ? animator.name : "NoAnimator";
+            var animatorName = FileNameGenerator.GetHierarchicalAnimatorName(animator);
             var generator = GetFileNameGenerator();
             return generator.GenerateUniqueFilePath("Assets", baseName, animatorName, ".fbx");
         }

--- a/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Tests/Editor/FileNameGeneratorHierarchyTests.cs
+++ b/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Tests/Editor/FileNameGeneratorHierarchyTests.cs
@@ -1,0 +1,183 @@
+using NUnit.Framework;
+using AnimationMergeTool.Editor.Infrastructure;
+using UnityEngine;
+
+namespace AnimationMergeTool.Editor.Tests
+{
+    /// <summary>
+    /// FileNameGenerator.GetHierarchicalAnimatorName の単体テスト
+    /// 親Animatorが存在する場合のファイル名生成を検証する
+    /// </summary>
+    public class FileNameGeneratorHierarchyTests
+    {
+        private GameObject _rootObj;
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_rootObj != null)
+            {
+                Object.DestroyImmediate(_rootObj);
+            }
+        }
+
+        [Test]
+        public void GetHierarchicalAnimatorName_親Animatorがない場合Animator名のみ返す()
+        {
+            // Arrange
+            _rootObj = new GameObject("MyCharacter");
+            var animator = _rootObj.AddComponent<Animator>();
+
+            // Act
+            var result = FileNameGenerator.GetHierarchicalAnimatorName(animator);
+
+            // Assert
+            Assert.AreEqual("MyCharacter", result);
+        }
+
+        [Test]
+        public void GetHierarchicalAnimatorName_親Animatorがある場合親名_子名を返す()
+        {
+            // Arrange
+            _rootObj = new GameObject("ParentModel");
+            _rootObj.AddComponent<Animator>();
+
+            var child = new GameObject("ChildModel");
+            child.transform.SetParent(_rootObj.transform);
+            var childAnimator = child.AddComponent<Animator>();
+
+            // Act
+            var result = FileNameGenerator.GetHierarchicalAnimatorName(childAnimator);
+
+            // Assert
+            Assert.AreEqual("ParentModel_ChildModel", result);
+        }
+
+        [Test]
+        public void GetHierarchicalAnimatorName_親にAnimatorがないGameObjectがある場合スキップして探す()
+        {
+            // Arrange - 構造: GrandParent(Animator) > Parent(なし) > Child(Animator)
+            _rootObj = new GameObject("GrandParent");
+            _rootObj.AddComponent<Animator>();
+
+            var parent = new GameObject("Parent");
+            parent.transform.SetParent(_rootObj.transform);
+            // ParentにはAnimatorなし
+
+            var child = new GameObject("Child");
+            child.transform.SetParent(parent.transform);
+            var childAnimator = child.AddComponent<Animator>();
+
+            // Act
+            var result = FileNameGenerator.GetHierarchicalAnimatorName(childAnimator);
+
+            // Assert - 最も近い親Animatorの名前が使われる
+            Assert.AreEqual("GrandParent_Child", result);
+        }
+
+        [Test]
+        public void GetHierarchicalAnimatorName_nullの場合NoAnimatorを返す()
+        {
+            // Act
+            var result = FileNameGenerator.GetHierarchicalAnimatorName(null);
+
+            // Assert
+            Assert.AreEqual("NoAnimator", result);
+        }
+
+        [Test]
+        public void GetHierarchicalAnimatorName_ルートにAnimatorがあり親がない場合名前のみ返す()
+        {
+            // Arrange
+            _rootObj = new GameObject("RootAnimator");
+            var animator = _rootObj.AddComponent<Animator>();
+
+            // Act
+            var result = FileNameGenerator.GetHierarchicalAnimatorName(animator);
+
+            // Assert
+            Assert.AreEqual("RootAnimator", result);
+        }
+
+        [Test]
+        public void GetHierarchicalAnimatorName_複数階層のAnimatorがある場合最も近い親を使う()
+        {
+            // Arrange - 構造: Root(Animator) > Middle(Animator) > Child(Animator)
+            _rootObj = new GameObject("Root");
+            _rootObj.AddComponent<Animator>();
+
+            var middle = new GameObject("Middle");
+            middle.transform.SetParent(_rootObj.transform);
+            middle.AddComponent<Animator>();
+
+            var child = new GameObject("Child");
+            child.transform.SetParent(middle.transform);
+            var childAnimator = child.AddComponent<Animator>();
+
+            // Act
+            var result = FileNameGenerator.GetHierarchicalAnimatorName(childAnimator);
+
+            // Assert - 最も近い親Animator（Middle）が使われる
+            Assert.AreEqual("Middle_Child", result);
+        }
+
+        [Test]
+        public void GetHierarchicalAnimatorName_ファイル名に反映される()
+        {
+            // Arrange
+            _rootObj = new GameObject("ParentModel");
+            _rootObj.AddComponent<Animator>();
+
+            var child = new GameObject("ChildModel");
+            child.transform.SetParent(_rootObj.transform);
+            var childAnimator = child.AddComponent<Animator>();
+
+            var generator = new FileNameGenerator();
+
+            // Act
+            var animatorName = FileNameGenerator.GetHierarchicalAnimatorName(childAnimator);
+            var baseName = generator.GenerateBaseName("MyTimeline", animatorName);
+
+            // Assert
+            Assert.AreEqual("MyTimeline_ParentModel_ChildModel_Merged.anim", baseName);
+        }
+
+        [Test]
+        public void GetHierarchicalAnimatorName_FBXファイル名にも反映される()
+        {
+            // Arrange
+            _rootObj = new GameObject("ParentModel");
+            _rootObj.AddComponent<Animator>();
+
+            var child = new GameObject("ChildModel");
+            child.transform.SetParent(_rootObj.transform);
+            var childAnimator = child.AddComponent<Animator>();
+
+            var generator = new FileNameGenerator();
+
+            // Act
+            var animatorName = FileNameGenerator.GetHierarchicalAnimatorName(childAnimator);
+            var baseName = generator.GenerateBaseName("MyTimeline", animatorName, ".fbx");
+
+            // Assert
+            Assert.AreEqual("MyTimeline_ParentModel_ChildModel_Merged.fbx", baseName);
+        }
+
+        [Test]
+        public void GetHierarchicalAnimatorName_親Animatorなしの場合ファイル名は従来通り()
+        {
+            // Arrange
+            _rootObj = new GameObject("MyAnimator");
+            var animator = _rootObj.AddComponent<Animator>();
+
+            var generator = new FileNameGenerator();
+
+            // Act
+            var animatorName = FileNameGenerator.GetHierarchicalAnimatorName(animator);
+            var baseName = generator.GenerateBaseName("MyTimeline", animatorName);
+
+            // Assert
+            Assert.AreEqual("MyTimeline_MyAnimator_Merged.anim", baseName);
+        }
+    }
+}

--- a/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Tests/Editor/FileNameGeneratorHierarchyTests.cs.meta
+++ b/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Tests/Editor/FileNameGeneratorHierarchyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d822a826ae809b84d823e79007aa290c

--- a/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Tests/Editor/SceneOffsetApplierTests.cs
+++ b/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Tests/Editor/SceneOffsetApplierTests.cs
@@ -1,0 +1,385 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using AnimationMergeTool.Editor.Domain;
+using UnityEditor;
+using UnityEngine;
+
+namespace AnimationMergeTool.Editor.Tests
+{
+    /// <summary>
+    /// SceneOffsetApplierクラスの単体テスト
+    /// </summary>
+    public class SceneOffsetApplierTests
+    {
+        private SceneOffsetApplier _applier;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _applier = new SceneOffsetApplier();
+        }
+
+        #region Positionオフセットテスト
+
+        [Test]
+        public void Apply_Positionオフセットがルートカーブに加算される()
+        {
+            // Arrange
+            var pairs = new List<CurveBindingPair>
+            {
+                CreateRootPositionCurve("m_LocalPosition.x", new Keyframe(0f, 1f), new Keyframe(1f, 2f)),
+                CreateRootPositionCurve("m_LocalPosition.y", new Keyframe(0f, 0f), new Keyframe(1f, 1f)),
+                CreateRootPositionCurve("m_LocalPosition.z", new Keyframe(0f, 3f), new Keyframe(1f, 4f))
+            };
+            var positionOffset = new Vector3(10f, 20f, 30f);
+
+            // Act
+            var result = _applier.Apply(pairs, positionOffset, Quaternion.identity);
+
+            // Assert
+            var xCurve = FindCurve(result, "m_LocalPosition.x");
+            var yCurve = FindCurve(result, "m_LocalPosition.y");
+            var zCurve = FindCurve(result, "m_LocalPosition.z");
+
+            Assert.IsNotNull(xCurve);
+            Assert.IsNotNull(yCurve);
+            Assert.IsNotNull(zCurve);
+
+            Assert.AreEqual(11f, xCurve.keys[0].value, 0.001f);
+            Assert.AreEqual(12f, xCurve.keys[1].value, 0.001f);
+            Assert.AreEqual(20f, yCurve.keys[0].value, 0.001f);
+            Assert.AreEqual(21f, yCurve.keys[1].value, 0.001f);
+            Assert.AreEqual(33f, zCurve.keys[0].value, 0.001f);
+            Assert.AreEqual(34f, zCurve.keys[1].value, 0.001f);
+        }
+
+        [Test]
+        public void Apply_Positionオフセットがゼロの場合カーブが変更されない()
+        {
+            // Arrange
+            var pairs = new List<CurveBindingPair>
+            {
+                CreateRootPositionCurve("m_LocalPosition.x", new Keyframe(0f, 1f)),
+                CreateRootPositionCurve("m_LocalPosition.y", new Keyframe(0f, 2f)),
+                CreateRootPositionCurve("m_LocalPosition.z", new Keyframe(0f, 3f))
+            };
+
+            // Act
+            var result = _applier.Apply(pairs, Vector3.zero, Quaternion.identity);
+
+            // Assert - 元のカーブと同じ値
+            var xCurve = FindCurve(result, "m_LocalPosition.x");
+            Assert.AreEqual(1f, xCurve.keys[0].value, 0.001f);
+        }
+
+        [Test]
+        public void Apply_子パスのカーブにはPositionオフセットが適用されない()
+        {
+            // Arrange
+            var childBinding = EditorCurveBinding.FloatCurve("Child", typeof(Transform), "m_LocalPosition.x");
+            var childCurve = new AnimationCurve(new Keyframe(0f, 5f));
+            var pairs = new List<CurveBindingPair>
+            {
+                new CurveBindingPair(childBinding, childCurve)
+            };
+            var positionOffset = new Vector3(10f, 0f, 0f);
+
+            // Act
+            var result = _applier.Apply(pairs, positionOffset, Quaternion.identity);
+
+            // Assert - 子パスのカーブは変更されない
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(5f, result[0].Curve.keys[0].value, 0.001f);
+        }
+
+        [Test]
+        public void Apply_Positionオフセットでタンジェントが保持される()
+        {
+            // Arrange
+            var key = new Keyframe(0f, 1f)
+            {
+                inTangent = 0.5f,
+                outTangent = 1.5f
+            };
+            var pairs = new List<CurveBindingPair>
+            {
+                CreateRootPositionCurve("m_LocalPosition.x", key)
+            };
+            var positionOffset = new Vector3(10f, 0f, 0f);
+
+            // Act
+            var result = _applier.Apply(pairs, positionOffset, Quaternion.identity);
+
+            // Assert
+            var xCurve = FindCurve(result, "m_LocalPosition.x");
+            Assert.AreEqual(0.5f, xCurve.keys[0].inTangent, 0.001f);
+            Assert.AreEqual(1.5f, xCurve.keys[0].outTangent, 0.001f);
+        }
+
+        #endregion
+
+        #region Rotationオフセットテスト
+
+        [Test]
+        public void Apply_Rotationオフセットがルートカーブに適用される()
+        {
+            // Arrange - 初期回転はIdentity (0,0,0,1)
+            var pairs = new List<CurveBindingPair>
+            {
+                CreateRootRotationCurve("m_LocalRotation.x", new Keyframe(0f, 0f)),
+                CreateRootRotationCurve("m_LocalRotation.y", new Keyframe(0f, 0f)),
+                CreateRootRotationCurve("m_LocalRotation.z", new Keyframe(0f, 0f)),
+                CreateRootRotationCurve("m_LocalRotation.w", new Keyframe(0f, 1f))
+            };
+
+            // Y軸90度回転のオフセット
+            var rotationOffset = Quaternion.Euler(0f, 90f, 0f);
+
+            // Act
+            var result = _applier.Apply(pairs, Vector3.zero, rotationOffset);
+
+            // Assert - offsetQ * identityQ = offsetQ
+            var xCurve = FindCurve(result, "m_LocalRotation.x");
+            var yCurve = FindCurve(result, "m_LocalRotation.y");
+            var zCurve = FindCurve(result, "m_LocalRotation.z");
+            var wCurve = FindCurve(result, "m_LocalRotation.w");
+
+            Assert.IsNotNull(xCurve);
+            Assert.IsNotNull(yCurve);
+            Assert.IsNotNull(zCurve);
+            Assert.IsNotNull(wCurve);
+
+            // offset * identity = offset
+            var expectedQ = rotationOffset;
+            Assert.AreEqual(expectedQ.x, xCurve.keys[0].value, 0.001f);
+            Assert.AreEqual(expectedQ.y, yCurve.keys[0].value, 0.001f);
+            Assert.AreEqual(expectedQ.z, zCurve.keys[0].value, 0.001f);
+            Assert.AreEqual(expectedQ.w, wCurve.keys[0].value, 0.001f);
+        }
+
+        [Test]
+        public void Apply_Rotationオフセットがidentityの場合カーブが変更されない()
+        {
+            // Arrange
+            var pairs = new List<CurveBindingPair>
+            {
+                CreateRootRotationCurve("m_LocalRotation.x", new Keyframe(0f, 0.1f)),
+                CreateRootRotationCurve("m_LocalRotation.y", new Keyframe(0f, 0.2f)),
+                CreateRootRotationCurve("m_LocalRotation.z", new Keyframe(0f, 0.3f)),
+                CreateRootRotationCurve("m_LocalRotation.w", new Keyframe(0f, 0.9f))
+            };
+
+            // Act
+            var result = _applier.Apply(pairs, Vector3.zero, Quaternion.identity);
+
+            // Assert - 元のカーブと同じ値
+            var xCurve = FindCurve(result, "m_LocalRotation.x");
+            Assert.AreEqual(0.1f, xCurve.keys[0].value, 0.001f);
+        }
+
+        [Test]
+        public void Apply_4つのRotationカーブが揃っていない場合スキップされる()
+        {
+            // Arrange - wカーブがない
+            var pairs = new List<CurveBindingPair>
+            {
+                CreateRootRotationCurve("m_LocalRotation.x", new Keyframe(0f, 0f)),
+                CreateRootRotationCurve("m_LocalRotation.y", new Keyframe(0f, 0f)),
+                CreateRootRotationCurve("m_LocalRotation.z", new Keyframe(0f, 0f))
+            };
+            var rotationOffset = Quaternion.Euler(0f, 90f, 0f);
+
+            // Act
+            var result = _applier.Apply(pairs, Vector3.zero, rotationOffset);
+
+            // Assert - カーブは変更されずにそのまま
+            Assert.AreEqual(3, result.Count);
+            Assert.AreEqual(0f, result[0].Curve.keys[0].value, 0.001f);
+        }
+
+        #endregion
+
+        #region 複合テスト
+
+        [Test]
+        public void Apply_PositionとRotation両方のオフセットが同時に適用される()
+        {
+            // Arrange
+            var pairs = new List<CurveBindingPair>
+            {
+                CreateRootPositionCurve("m_LocalPosition.x", new Keyframe(0f, 1f)),
+                CreateRootPositionCurve("m_LocalPosition.y", new Keyframe(0f, 2f)),
+                CreateRootPositionCurve("m_LocalPosition.z", new Keyframe(0f, 3f)),
+                CreateRootRotationCurve("m_LocalRotation.x", new Keyframe(0f, 0f)),
+                CreateRootRotationCurve("m_LocalRotation.y", new Keyframe(0f, 0f)),
+                CreateRootRotationCurve("m_LocalRotation.z", new Keyframe(0f, 0f)),
+                CreateRootRotationCurve("m_LocalRotation.w", new Keyframe(0f, 1f))
+            };
+            var positionOffset = new Vector3(5f, 10f, 15f);
+            var rotationOffset = Quaternion.Euler(0f, 90f, 0f);
+
+            // Act
+            var result = _applier.Apply(pairs, positionOffset, rotationOffset);
+
+            // Assert - Positionが加算されている
+            var xCurve = FindCurve(result, "m_LocalPosition.x");
+            Assert.AreEqual(6f, xCurve.keys[0].value, 0.001f);
+
+            // Assert - Rotationが適用されている
+            var qyCurve = FindCurve(result, "m_LocalRotation.y");
+            Assert.AreEqual(rotationOffset.y, qyCurve.keys[0].value, 0.001f);
+        }
+
+        [Test]
+        public void Apply_nullのカーブリストの場合nullを返す()
+        {
+            // Act
+            var result = _applier.Apply(null, Vector3.one, Quaternion.identity);
+
+            // Assert
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void Apply_空のカーブリストの場合空を返す()
+        {
+            // Act
+            var result = _applier.Apply(new List<CurveBindingPair>(), Vector3.one, Quaternion.identity);
+
+            // Assert
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [Test]
+        public void Apply_オフセット対象外のカーブもそのまま残る()
+        {
+            // Arrange - BlendShapeカーブ（オフセット適用対象外）
+            var blendShapeBinding = EditorCurveBinding.FloatCurve("Face", typeof(SkinnedMeshRenderer), "blendShape.smile");
+            var blendShapeCurve = new AnimationCurve(new Keyframe(0f, 50f));
+            var pairs = new List<CurveBindingPair>
+            {
+                CreateRootPositionCurve("m_LocalPosition.x", new Keyframe(0f, 1f)),
+                CreateRootPositionCurve("m_LocalPosition.y", new Keyframe(0f, 0f)),
+                CreateRootPositionCurve("m_LocalPosition.z", new Keyframe(0f, 0f)),
+                new CurveBindingPair(blendShapeBinding, blendShapeCurve)
+            };
+            var positionOffset = new Vector3(10f, 0f, 0f);
+
+            // Act
+            var result = _applier.Apply(pairs, positionOffset, Quaternion.identity);
+
+            // Assert - BlendShapeカーブが残っている
+            CurveBindingPair blendShapePair = null;
+            foreach (var pair in result)
+            {
+                if (pair.Binding.propertyName == "blendShape.smile")
+                {
+                    blendShapePair = pair;
+                    break;
+                }
+            }
+            Assert.IsNotNull(blendShapePair);
+            Assert.AreEqual(50f, blendShapePair.Curve.keys[0].value, 0.001f);
+        }
+
+        #endregion
+
+        #region Humanoidルートモーションカーブテスト
+
+        [Test]
+        public void Apply_HumanoidのRootTカーブにPositionオフセットが適用される()
+        {
+            // Arrange
+            var pairs = new List<CurveBindingPair>
+            {
+                CreateRootMotionPositionCurve("RootT.x", new Keyframe(0f, 1f)),
+                CreateRootMotionPositionCurve("RootT.y", new Keyframe(0f, 2f)),
+                CreateRootMotionPositionCurve("RootT.z", new Keyframe(0f, 3f))
+            };
+            var positionOffset = new Vector3(10f, 20f, 30f);
+
+            // Act
+            var result = _applier.Apply(pairs, positionOffset, Quaternion.identity);
+
+            // Assert
+            var xCurve = FindCurve(result, "RootT.x");
+            var yCurve = FindCurve(result, "RootT.y");
+            var zCurve = FindCurve(result, "RootT.z");
+
+            Assert.AreEqual(11f, xCurve.keys[0].value, 0.001f);
+            Assert.AreEqual(22f, yCurve.keys[0].value, 0.001f);
+            Assert.AreEqual(33f, zCurve.keys[0].value, 0.001f);
+        }
+
+        [Test]
+        public void Apply_HumanoidのRootQカーブにRotationオフセットが適用される()
+        {
+            // Arrange - identity quaternion
+            var pairs = new List<CurveBindingPair>
+            {
+                CreateRootMotionRotationCurve("RootQ.x", new Keyframe(0f, 0f)),
+                CreateRootMotionRotationCurve("RootQ.y", new Keyframe(0f, 0f)),
+                CreateRootMotionRotationCurve("RootQ.z", new Keyframe(0f, 0f)),
+                CreateRootMotionRotationCurve("RootQ.w", new Keyframe(0f, 1f))
+            };
+            var rotationOffset = Quaternion.Euler(0f, 90f, 0f);
+
+            // Act
+            var result = _applier.Apply(pairs, Vector3.zero, rotationOffset);
+
+            // Assert
+            var xCurve = FindCurve(result, "RootQ.x");
+            var yCurve = FindCurve(result, "RootQ.y");
+
+            Assert.IsNotNull(xCurve);
+            Assert.IsNotNull(yCurve);
+            Assert.AreEqual(rotationOffset.y, yCurve.keys[0].value, 0.001f);
+        }
+
+        #endregion
+
+        #region ヘルパーメソッド
+
+        private CurveBindingPair CreateRootPositionCurve(string propertyName, params Keyframe[] keys)
+        {
+            var binding = EditorCurveBinding.FloatCurve("", typeof(Transform), propertyName);
+            var curve = new AnimationCurve(keys);
+            return new CurveBindingPair(binding, curve);
+        }
+
+        private CurveBindingPair CreateRootRotationCurve(string propertyName, params Keyframe[] keys)
+        {
+            var binding = EditorCurveBinding.FloatCurve("", typeof(Transform), propertyName);
+            var curve = new AnimationCurve(keys);
+            return new CurveBindingPair(binding, curve);
+        }
+
+        private CurveBindingPair CreateRootMotionPositionCurve(string propertyName, params Keyframe[] keys)
+        {
+            var binding = EditorCurveBinding.FloatCurve("", typeof(Animator), propertyName);
+            var curve = new AnimationCurve(keys);
+            return new CurveBindingPair(binding, curve);
+        }
+
+        private CurveBindingPair CreateRootMotionRotationCurve(string propertyName, params Keyframe[] keys)
+        {
+            var binding = EditorCurveBinding.FloatCurve("", typeof(Animator), propertyName);
+            var curve = new AnimationCurve(keys);
+            return new CurveBindingPair(binding, curve);
+        }
+
+        private AnimationCurve FindCurve(List<CurveBindingPair> pairs, string propertyName)
+        {
+            foreach (var pair in pairs)
+            {
+                if (pair.Binding.propertyName == propertyName && pair.Binding.path == "")
+                {
+                    return pair.Curve;
+                }
+            }
+            return null;
+        }
+
+        #endregion
+    }
+}

--- a/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Tests/Editor/SceneOffsetApplierTests.cs.meta
+++ b/AnimationMergeToolForTimeline/Packages/AnimationMergeToolForTimeline/Tests/Editor/SceneOffsetApplierTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 87bb7181f913dad43bf17e66f8c5bf4d


### PR DESCRIPTION
- AnimationPlayableAsset.position/rotationのシーンオフセットをマージ結果に反映
  - ClipInfoにSceneOffsetPosition/SceneOffsetRotationプロパティを追加
  - SceneOffsetApplierクラスを新規作成（Transform/Humanoid両方のルートカーブに対応）
  - ClipMerger.Merge()内で時間オフセット後にシーンオフセットを適用
- ファイル名に親Animator階層を反映
  - FileNameGenerator.GetHierarchicalAnimatorName()で親Animator検出
  - 親Animatorがある場合「親名_子名」形式のファイル名を生成
  - AnimationMergeService/ContextMenuHandlerの全3箇所で使用